### PR TITLE
fix the exception caused by passing password by "-p"

### DIFF
--- a/main.c
+++ b/main.c
@@ -33,6 +33,7 @@ int main(int argc, char **argv) {
 	char *interface = NULL;
 	char *username = NULL;
 	char *password = NULL;
+	int can_free_pw = 0;
 
 	while ((ch = getopt(argc, argv, "i:u:p:h")) != -1) {
 		switch (ch) {
@@ -82,6 +83,7 @@ int main(int argc, char **argv) {
 
 		echo_off();
 		fgets(password, PWD_LEN - 1, stdin);
+		can_free_pw = 1;
 		echo_on();
 
 		/* replace '\n' with '\0', as it is NOT part of password */
@@ -91,10 +93,14 @@ int main(int argc, char **argv) {
 
 	if (h3c_set_password(password) != SUCCESS) {
 		fprintf(stderr, "Failed to set password.\n");
-		free(password);
+		if (can_free_pw) {
+			free(password);
+		}
 		exit(-1);
 	}
-	free(password);
+	if (can_free_pw) {
+		free(password);
+	}
 
 	if (h3c_init(interface) != SUCCESS) {
 		fprintf(stderr, "Failed to initialize: %s\n", strerror(errno));


### PR DESCRIPTION
BUG内容为：使用-p参数时，free(password)运行错误。
导致这个错误的原因如下：
char *password指向的是getopt()函数解析的参数值数组指针optarg。
在getopt()的实现中，optarg指向的是nargv[optind++]（也就是*nargv）。而函数定义中有char * const *nargv，所以optarq指向的是const指针。
程序后部分有有free(password)，此时password接收的是一个const类型指针，不能被释放，导致程序出错。
大致修复逻辑：
加入判断，如果只有在没有用-p参数才free(password)